### PR TITLE
Fixed ocr typeError issue when using python3.9

### DIFF
--- a/OCR/florence/model.py
+++ b/OCR/florence/model.py
@@ -6,13 +6,14 @@ from Levenshtein import distance as levenshtein_distance
 from unittest.mock import patch
 from transformers.dynamic_module_utils import get_imports
 from transformers import AutoModelForCausalLM, AutoProcessor
+from typing import Union
 
 class Model:
     def __init__(self, context):
         self.context = context
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     
-    def fixed_get_imports(self, filename: str | os.PathLike) -> list[str]:
+    def fixed_get_imports(self, filename: Union[str, os.PathLike]) -> list[str]:
         if not str(filename).endswith("modeling_florence2.py"):
             return get_imports(filename)
         imports = get_imports(filename)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected type hint for the `filename` parameter in the OCR model to improve compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->